### PR TITLE
chore: add sonar-maven-plugin config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,8 @@
   <properties>
     <rootPackage>io.kestros.commons.osgiserviceutils</rootPackage>
     <bundleCategory>kestros</bundleCategory>
+    <sonar.host.url>http://192.168.86.216:9090</sonar.host.url>
+    <sonar.projectKey>kestros-osgi-service-utils</sonar.projectKey>
   </properties>
 
   <dependencies>
@@ -57,6 +59,15 @@
   <build>
     <sourceDirectory>src/main/java</sourceDirectory>
     <testSourceDirectory>src/test/java</testSourceDirectory>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.sonarsource.scanner.maven</groupId>
+          <artifactId>sonar-maven-plugin</artifactId>
+          <version>3.11.0.3922</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 
 </project>


### PR DESCRIPTION
## Summary

- Adds `sonar.host.url` and `sonar.projectKey` properties to `pom.xml`
- Adds `sonar-maven-plugin` 3.11.0.3922 to plugin management

## Related

TASK-194 — Set up SonarQube

## Notes

Manual scan verification (`mvn sonar:sonar`) requires the SonarQube server to be running at http://192.168.86.216:9090. Server setup is SSH-dependent (Docker on the dev server) — blocked until Danny brings up the Docker container.